### PR TITLE
docs(para-mcp-server): 📚 clarify pregenerated-wallet APIs use and update response/env fields

### DIFF
--- a/typescript/lib/mcp-tools/para-mcp-server/.env.example
+++ b/typescript/lib/mcp-tools/para-mcp-server/.env.example
@@ -31,10 +31,13 @@ OPENROUTER_API_KEY=
 MNEMONIC=""
 
 ALLORA_API_KEY=
+# https://developer.getpara.com/
 NEXT_PUBLIC_PARA_API_KEY=
 PARA_API_KEY=
-COINBASE_PAYMASTER_URL=
-
 # Coinbase Developer Platform API credentials for faucet requests
 # Get your CDP API keys here: https://portal.cdp.coinbase.com/
+COINBASE_PAYMASTER_URL=
+CDP_API_KEY_ID=
+CDP_API_KEY_SECRET=
+
 

--- a/typescript/lib/mcp-tools/para-mcp-server/README.md
+++ b/typescript/lib/mcp-tools/para-mcp-server/README.md
@@ -23,22 +23,22 @@ A Model Context Protocol (MCP) server that wraps the [Para Server SDK](https://d
 ## 🧰 Tools Available
 
 ### `create_pregen_wallet`
-Create (or cache) a pregenerated wallet for the supplied identifier. If Para already has a wallet, the tool seeds a placeholder entry locally.
+Create (or cache) a pregenerated wallet for the supplied email. If Para already has a wallet, the tool seeds a placeholder entry locally. Always creates EVM wallets.
 
 **Parameters**
-- `identifier` *(string, required)* – Unique identifier value (email, phone, etc.).
-- `identifierType` *(enum, default `email`)* – One of `email`, `phone`, `username`, `id`, `custom`.
-- `walletType` *(enum, default `EVM`)* – One of `EVM`, `SOLANA`, `COSMOS`.
+- `email` *(string, required)* – Email address for pregenerated wallet (must be valid email format).
 
 **Response Artifact (text JSON)**
 ```json
 {
+  "recordId": "550e8400-e29b-41d4-a716-446655440000",
   "walletId": "mock-wallet-id",
-  "identifierKey": "email",
-  "identifierValue": "user@example.com",
-  "walletType": "EVM",
+  "address": "0x1234...abcd",
+  "email": "user@example.com",
   "userShareJson": "{\"share\":\"...\"}",
-  "createdAt": "2025-09-23T12:34:56.000Z"
+  "createdAt": "2025-09-23T12:34:56.000Z",
+  "isClaimed": false,
+  "rawWallet": {}
 }
 ```
 
@@ -53,14 +53,12 @@ Return the entire in-memory cache of pregenerated wallets.
 Fetch a cached wallet's identifier metadata and user share for client-side claiming flows.
 
 **Parameters**
-- `identifier` *(string, required)*
-- `identifierType` *(enum, default `email`)*
+- `email` *(string, required)* – Email address for pregenerated wallet (must be valid email format).
 
 **Response Artifact (text JSON)**
 ```json
 {
-  "identifierKey": "email",
-  "identifierValue": "user@example.com",
+  "email": "user@example.com",
   "address": "0x1234...abcd",
   "isClaimed": false,
   "note": "This pregenerated wallet is not claimed. You can claim it from the frontend using the Claim button."
@@ -94,15 +92,13 @@ Request testnet faucet funds from Coinbase CDP for Base Sepolia or other support
 - cbBTC: 0.0001 per request, 0.001 max per 24h
 
 ### `transfer_eth`
-Transfer ETH from a pregenerated wallet to another address on Base Sepolia or other supported EVM test networks. Looks up the wallet by identifier (e.g., email like panda@gmail.com), loads the userShare from memory, and executes the transfer using Para's transfer method. Amount is specified in ETH (e.g., "0.001") and automatically converted to wei.
+Transfer ETH from a pregenerated wallet to another address on Base Sepolia or other supported EVM test networks. Looks up the wallet by email, loads the userShare from memory, and executes the transfer using Para's transfer method. Amount is specified in ETH (e.g., "0.001") and automatically converted to wei.
 
 **Parameters**
-- `identifier` *(string, required)* – Unique identifier for the pregenerated wallet (e.g., `panda@gmail.com`)
-- `identifierType` *(enum, default `email`)* – One of `email`, `phone`, `username`, `id`, `custom`
+- `email` *(string, required)* – Email address for the pregenerated wallet (e.g., `panda@gmail.com`, must be valid email format)
 - `recipientAddress` *(string, required)* – Recipient Ethereum address (must be valid 0x... format)
 - `amount` *(string, required)* – Amount to transfer in ETH (e.g., `"0.001"` for 0.001 ETH, `"0.00001"` for 0.00001 ETH)
 - `network` *(enum, default `base-sepolia`)* – One of `base-sepolia`, `ethereum-sepolia`, `ethereum-holesky`, `arbitrum-sepolia`
-- `rpcUrl` *(string, optional)* – Custom RPC URL for the transaction
 
 **Response Artifact (text JSON)**
 ```json
@@ -133,7 +129,6 @@ Check ETH balance of any Ethereum address on Base Sepolia or other supported EVM
 **Parameters**
 - `address` *(string, required)* – Ethereum address to check balance for (must be valid 0x... format)
 - `network` *(enum, default `base-sepolia`)* – One of `base-sepolia`, `ethereum-sepolia`, `ethereum-holesky`, `arbitrum-sepolia`
-- `rpcUrl` *(string, optional)* – Custom RPC URL for the query
 
 **Response Artifact (text JSON)**
 ```json
@@ -159,12 +154,10 @@ pnpm balance:check 0x742d35Cc6634C0532925a3b844Bc454e4438f44e
 pnpm balance:check 0x742d35Cc6634C0532925a3b844Bc454e4438f44e arbitrum-sepolia
 ```
 
-**Parameters**: none
-
 ### Environment Variables
 - `PARA_API_KEY` *(required)* – Server-side Para API key used to instantiate the SDK client.
 - `PARA_ENVIRONMENT` *(optional)* – `BETA` (default) or `PRODUCTION`; mapped to `Environment` enum in the SDK.
-- `CDP_API_KEY_NAME` *(required for faucet)* – Coinbase Developer Platform API key name for JWT authentication.
+- `CDP_API_KEY_ID` *(required for faucet)* – Coinbase Developer Platform API key ID for JWT authentication.
 - `CDP_API_KEY_SECRET` *(required for faucet)* – Coinbase Developer Platform API key secret (PEM format) for JWT authentication.
 - `PORT` *(optional)* – HTTP server port (defaults to `3012`).
 

--- a/typescript/lib/mcp-tools/para-mcp-server/example-integration.md
+++ b/typescript/lib/mcp-tools/para-mcp-server/example-integration.md
@@ -22,13 +22,13 @@ PARA_ENVIRONMENT=BETA        # or PRODUCTION
 PORT=3012                    # optional; defaults to 3012
 
 # Required for faucet functionality
-CDP_API_KEY_NAME=your_cdp_api_key_name
+CDP_API_KEY_ID=your_CDP_API_KEY_ID
 CDP_API_KEY_SECRET=your_cdp_api_key_secret_pem
 ```
 
 > The server throws a `MissingParaApiKey` error if `PARA_API_KEY` is absent, so make sure the value is injected in development and production environments.
 > 
-> The `CDP_API_KEY_NAME` and `CDP_API_KEY_SECRET` are only required if you want to use the `request_faucet` tool to get testnet funds. Get your credentials at https://portal.cdp.coinbase.com/
+> The `CDP_API_KEY_ID` and `CDP_API_KEY_SECRET` are only required if you want to use the `request_faucet` tool to get testnet funds. Get your credentials at https://portal.cdp.coinbase.com/
 
 ## 3. Run the Server
 


### PR DESCRIPTION
Update README for para-mcp-server:
- Replace generic "identifier params with explicit `email` where endpoints expect an email
- Clarify create_pregen_wallet always creates EVM wallets and adjust response JSON (add recordId, address, email, isClaimed, rawWallet; remove identifierKey/Value/walletType)
- Update transfer_eth and fetch-wallet docs to reference email
- Remove optional rpcUrl mentions for some endpoints
- Rename CDP API env var from CDP_API_KEY_NAME to CDP_API_KEY_ID and update example

This is a docs-only change; no code modified.